### PR TITLE
Fix GitHub Action and update to test both IC & IU

### DIFF
--- a/.github/workflows/plugin_compatibility.yml
+++ b/.github/workflows/plugin_compatibility.yml
@@ -11,7 +11,8 @@ jobs:
         java-version: 8.x.x
     - name: Build the plugin using Gradle
       run: ./gradlew buildPlugin
-    - uses: thepieterdc/intellij-plugin-verifier-action@v1.0.0
+    - uses: ChrisCarini/intellij-platform-plugin-verifier-action@v1.0.3
       with:
-        plugin: '/home/runner/work/flutter_enhancement_suite/flutter_enhancement_suite/build/distributions/Flutter Enhancement Suite-1.3.2.zip'
-        version: '193.5662.53'
+        ide-versions: |
+          ideaIC:193.5662.53
+          ideaIU:193.5662.53


### PR DESCRIPTION
Hi @marius-h - It looks like when you first added this file, it wasn't placed in the correct directory for GitHub to pickup - per the [GitHub Quickstart for GitHub Actions](https://docs.github.com/en/actions/quickstart#creating-your-first-workflow), the file should be located under the `.github/workflows` directory in your project. As such, I've moved the `plugin_compatibility.yml` file to that directory.

Additionally, I've made a change to also test both IJ Community, and IJ Ultimate - other IDEs can also be tested if desired, see here for docs: https://github.com/ChrisCarini/intellij-platform-plugin-verifier-action#ide-versions