### PR TITLE
Add support for custom file templates provided by the user

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = de.mariushoefler.flutter_enhancement_suite
 pluginName = Flutter Enhancement Suite
-pluginVersion = 1.5.1
+pluginVersion = 1.5.2
 pluginSinceBuild = 201
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions

--- a/src/main/kotlin/de/mariushoefler/flutterenhancementsuite/actions/CustomFlutterTemplateManager.kt
+++ b/src/main/kotlin/de/mariushoefler/flutterenhancementsuite/actions/CustomFlutterTemplateManager.kt
@@ -1,0 +1,63 @@
+package de.mariushoefler.flutterenhancementsuite.actions
+
+import com.intellij.ide.actions.CreateFileFromTemplateDialog
+import com.intellij.ide.fileTemplates.FileTemplate
+import com.intellij.ide.fileTemplates.impl.CustomFileTemplate
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
+import icons.FlutterIcons
+import java.io.File
+
+private const val CUSTOM_TEMPLATES_PATH = ".flutter_file_templates/"
+private const val CUSTOM_FILE_TEMPLATE_NAME_PREFIX = "@custom:"
+private const val VELOCITY_FILE_TEMPLATE_SUFFIX = ".ft"
+
+/**
+ * Custom template manager
+ *
+ * Allows users to add their own file templates inside "New Flutter Widget" action.
+ *
+ * @author Karol Czeryna
+ * @since v1.5.0
+ */
+class CustomFlutterTemplateManager {
+    fun isCustomFileTemplate(templateName: String): Boolean = templateName.startsWith(CUSTOM_FILE_TEMPLATE_NAME_PREFIX)
+
+    fun appendCustomFileTemplatesTo(builder: CreateFileFromTemplateDialog.Builder, project: Project) =
+        findCustomTemplates(project)
+            .forEach {
+                val customTemplateName = it.name.substringBefore('.')
+                val kind = customTemplateName.snakeCaseToTemplateName()
+                builder.addKind(kind, FlutterIcons.Flutter, CUSTOM_FILE_TEMPLATE_NAME_PREFIX + customTemplateName)
+            }
+
+    fun createCustomFileTemplate(templateName: String, project: Project): FileTemplate? {
+        val templateFilename = templateName.removePrefix(CUSTOM_FILE_TEMPLATE_NAME_PREFIX)
+        val templateFile = findCustomTemplates(project)
+            .firstOrNull { it.name.substringBefore('.') == templateFilename }
+
+        templateFile ?: return null
+
+        return CustomFileTemplate(
+            templateFilename,
+            computeExtensionFromFileTemplate(templateFile.name),
+        ).apply { text = templateFile.readText() }
+    }
+
+    private fun findCustomTemplates(project: Project): Array<File> {
+        val templatesDir = computeCustomTemplatesDirectory(project)
+        return templatesDir?.listFiles() ?: arrayOf()
+    }
+
+    private fun computeCustomTemplatesDirectory(project: Project): File? {
+        return project.guessProjectDir()
+            ?.toNioPath()
+            ?.resolve(CUSTOM_TEMPLATES_PATH)
+            ?.toFile()
+    }
+
+    private fun computeExtensionFromFileTemplate(filename: String) =
+        filename.removeSuffix(VELOCITY_FILE_TEMPLATE_SUFFIX).substringAfter('.')
+
+    private fun String.snakeCaseToTemplateName() = split('_').joinToString(" ", transform = String::capitalize)
+}

--- a/src/main/kotlin/de/mariushoefler/flutterenhancementsuite/actions/NewFlutterWidgetAction.kt
+++ b/src/main/kotlin/de/mariushoefler/flutterenhancementsuite/actions/NewFlutterWidgetAction.kt
@@ -15,19 +15,38 @@ import com.jetbrains.lang.dart.sdk.DartSdk
 import de.mariushoefler.flutterenhancementsuite.utils.toSnakeCase
 import icons.FlutterIcons
 
-class NewFlutterWidgetAction :
-    CreateFileFromTemplateAction("Flutter Widget", "Create a new Flutter widget", FlutterIcons.Flutter) {
-    override fun createFileFromTemplate(name: String?, template: FileTemplate?, dir: PsiDirectory?): PsiFile {
-        return super.createFileFromTemplate(name?.toSnakeCase(), template, dir)
-    }
+class NewFlutterWidgetAction(
+    private val customTemplatesManager: CustomFlutterTemplateManager = CustomFlutterTemplateManager()
+) : CreateFileFromTemplateAction("Flutter Widget", "Create a new Flutter widget", FlutterIcons.Flutter) {
 
     override fun buildDialog(project: Project, directory: PsiDirectory, builder: CreateFileFromTemplateDialog.Builder) {
         builder
             .setTitle("New Flutter Widget")
-            ?.addKind("Stateless widget", FlutterIcons.Flutter, "stateless_widget")
-            ?.addKind("Stateful widget", FlutterIcons.Flutter, "stateful_widget")
-            ?.addKind("Stateful widget with AnimationController", FlutterIcons.Flutter, "animated_widget")
-            ?.addKind("Inherited widget", FlutterIcons.Flutter, "inherited_widget")
+            .addKind("Stateless widget", FlutterIcons.Flutter, "stateless_widget")
+            .addKind("Stateful widget", FlutterIcons.Flutter, "stateful_widget")
+            .addKind("Stateful widget with AnimationController", FlutterIcons.Flutter, "animated_widget")
+            .addKind("Inherited widget", FlutterIcons.Flutter, "inherited_widget")
+
+        builder.appendCustomFileTemplates(project)
+    }
+
+    private fun CreateFileFromTemplateDialog.Builder.appendCustomFileTemplates(project: Project) =
+        customTemplatesManager.appendCustomFileTemplatesTo(this, project)
+
+    override fun createFile(name: String, templateName: String, dir: PsiDirectory): PsiFile? {
+        if (customTemplatesManager.isCustomFileTemplate(templateName)) {
+            val template = customTemplatesManager.createCustomFileTemplate(templateName, dir.project)
+
+            return template
+                ?.let { createFileFromTemplate(name, template, dir) }
+                ?: super.createFile(name, templateName, dir)
+        }
+
+        return super.createFile(name, templateName, dir)
+    }
+
+    override fun createFileFromTemplate(name: String?, template: FileTemplate?, dir: PsiDirectory?): PsiFile {
+        return super.createFileFromTemplate(name?.toSnakeCase(), template, dir)
     }
 
     override fun isAvailable(dataContext: DataContext?): Boolean {


### PR DESCRIPTION
This PR introduces support for custom, user-provided templates. One of the rationales behind this PR is that not everyone uses BLOC, and pulling templates from config dir allows teams of developers to use their own templates for components that manage state.

It's rather primitive at the moment, but I hope it's a good starting point.

https://user-images.githubusercontent.com/15970653/113207036-72814900-9270-11eb-8169-a1272f012758.mp4

