### PR TITLE
Update file templates 

### DIFF
--- a/src/main/resources/fileTemplates/internal/animated_widget.dart.ft
+++ b/src/main/resources/fileTemplates/internal/animated_widget.dart.ft
@@ -10,11 +10,11 @@ class ${CamelCaseName} extends StatefulWidget {
   const ${CamelCaseName}({Key? key}) : super(key: key);
 
   @override
-  _${CamelCaseName}State createState() => _${CamelCaseName}State();
+  State<_${CamelCaseName}> createState() => _${CamelCaseName}State();
 }
 
 class _${CamelCaseName}State extends State<${CamelCaseName}> with SingleTickerProviderStateMixin {
-  AnimationController _controller;
+  late AnimationController _controller;
 
   @override
   void initState() {

--- a/src/main/resources/fileTemplates/internal/stateful_widget.dart.ft
+++ b/src/main/resources/fileTemplates/internal/stateful_widget.dart.ft
@@ -10,7 +10,7 @@ class ${CamelCaseName} extends StatefulWidget {
   const ${CamelCaseName}({Key? key}) : super(key: key);
 
   @override
-  _${CamelCaseName}State createState() => _${CamelCaseName}State();
+  State<_${CamelCaseName}> createState() => _${CamelCaseName}State();
 }
 
 class _${CamelCaseName}State extends State<${CamelCaseName}> {


### PR DESCRIPTION
The new file templates for StatefulWidget and StatefulWidget with AnimationController both leak the private State implementations. The official plugin's live template already avoid this so I updated the templates to avoid that here as well.

The template for StatefulWidget with an AnimationController also does not compile, since _controller is not initialised in null safe code. I fixed that by making the declaration late.